### PR TITLE
Return an empty dictionary when invoked with `get` and a non-Azure container registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Next, in `$HOME/.docker/config.json`, either add:
 to handle requests for all Azure registries, or
 ```json
 {
-    "credsHelper": {
+    "credHelpers": {
         "<registry>.azurecr.io": "acr-login"
     }
 }


### PR DESCRIPTION
Also fix the reference for `credHelpers` (instead of `credsHelper`)