### PR TITLE
fix: pass tenant ID when acquiring Azure access token

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 
 use azure_core::credentials::TokenCredential;
-use azure_identity::DeveloperToolsCredential;
+use azure_identity::{AzureCliCredential, AzureCliCredentialOptions};
 use clap::{Parser, crate_name};
 use log::{info, trace};
 use serde::Deserialize;
@@ -95,12 +95,18 @@ async fn get_docker_credential(cli: &Cli) -> StdResult<serde_json::Value> {
     // Need to connect to the repository's OAuth endpoint to exchange the token we just got.
     let url = Url::parse(&format!("https://{registry}/oauth2/exchange"))?;
 
-    // Time to obtain some credentials and variables!
-    let credential = DeveloperToolsCredential::new(None)?;
+    // Obtain an Azure access token scoped to management.azure.com for this
+    // specific tenant. Using AzureCliCredential with tenant_id ensures
+    // `az account get-access-token --tenant` is called, so the active
+    // subscription does not need to match the ACR's tenant.
+    let tenant = &cli.azure_tenant_id;
+    let credential = AzureCliCredential::new(Some(AzureCliCredentialOptions {
+        tenant_id: Some(tenant.clone()),
+        ..Default::default()
+    }))?;
     let token_response = credential
         .get_token(&["https://management.azure.com/.default"], None)
         .await?;
-    let tenant = &cli.azure_tenant_id;
 
     // Set up the parameters for the post to the OAuth endpoint as per
     // https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md#calling-post-oauth2exchange-to-get-an-acr-refresh-token


### PR DESCRIPTION
## Problem

`AZURE_TENANT_ID` is accepted as a CLI argument/env var and used correctly when exchanging the token at the ACR OAuth endpoint — but it is **not** passed when acquiring the initial Azure access token. The code uses `DeveloperToolsCredential`, which internally constructs `AzureCliCredential` with `tenant_id: None`, so it calls:

```
az account get-access-token
```

without `--tenant`. The token is therefore always acquired for the **active subscription's tenant**, regardless of the `AZURE_TENANT_ID` value.

This means using the binary for an ACR that lives in a different tenant than the currently active subscription requires the caller to run `az account set --subscription` first, which is fragile and breaks Docker credential helper use cases (e.g. where Docker calls the helper directly without a surrounding shell session).

## Fix

Replace `DeveloperToolsCredential` with `AzureCliCredential` constructed with `tenant_id` set from the parsed CLI argument. This ensures:

```
az account get-access-token --tenant <id>
```

is called, which works correctly regardless of which subscription is currently active, as long as the user has authenticated to the target tenant at least once via `az login`.

## Trade-off

`DeveloperToolsCredential` also falls back to `AzureDeveloperCliCredential` (azd). This PR drops that fallback in favour of correct tenant handling. Users relying on `azd` instead of `az` would be unaffected today because `AzureDeveloperCliCredential` also has no tenant_id propagation in the current code. A follow-up could add an `--azure-developer-cli` flag or similar if azd support is needed.

## Testing

Verified locally that `echo -n "myregistry.azurecr.io" | docker-credential-acr-login get --azure-tenant-id <tenant-id>` now returns valid credentials without needing the active subscription to match the target tenant.